### PR TITLE
CoCo - Add Appkeys,  OP_NET Bus support so network ops work now

### DIFF
--- a/coco/src/bus/bus_get_response.c
+++ b/coco/src/bus/bus_get_response.c
@@ -18,17 +18,46 @@ uint8_t bus_get_response(uint8_t opcode, uint8_t *buf, int len)
     struct _getresponsecmd
     {
         uint8_t opcode;
-        uint8_t command;
+        uint8_t p1;
+        uint8_t p2;
+        uint16_t auxs;
     } grc;
-
-    uint8_t z=0;
     
+    uint8_t z=sizeof(grc);
+
     grc.opcode = opcode;
-    grc.command = FUJICMD_GET_RESPONSE;
+
+    if (opcode == OP_NET) {
+        grc.p1 = 1; // Firmware appears to ignore unit
+        grc.p2 = FUJICMD_GET_RESPONSE;
+        grc.auxs = len;
+    } else { // OP_FUJI
+        grc.p1 = FUJICMD_GET_RESPONSE;
+        z=2;   
+    }
 
     bus_ready();
-    dwwrite((uint8_t *)&grc, sizeof(grc));
-    dwread((uint8_t *)buf, len);
-    
-    return z;
+    dwwrite((uint8_t *)&grc, z);
+
+    // Return 0 on a successful read (dwread returns 1)
+    return !dwread((uint8_t *)buf, len);
 }
+/*
+ struct _getresponsecmd
+    {
+        byte opcode;
+        byte id;
+        byte command;
+        int len;
+    } grc;
+    
+    grc.opcode = OP_NET;
+    grc.id = 1;
+    grc.command = FUJICMD_GET_RESPONSE;
+    grc.len = len;
+
+    bus_ready();
+    dwwrite((byte *)&grc, sizeof(grc));
+
+    // Returns 0 on a successful read
+    return !dwread((byte *)buf, len);*/

--- a/coco/src/bus/bus_ready.c
+++ b/coco/src/bus/bus_ready.c
@@ -19,7 +19,7 @@ void bus_ready(void)
         uint8_t command;
     } rc;
 
-    uint8_t z=0, r=0;
+    uint8_t z=0, r;
     
     rc.opcode = OP_FUJI;
     rc.command = FUJICMD_READY;

--- a/coco/src/fn_fuji/fuji_read_appkey.c
+++ b/coco/src/fn_fuji/fuji_read_appkey.c
@@ -4,23 +4,52 @@
 #include <dw.h>
 #include <fujinet-fuji-coco.h>
 
+extern uint16_t ak_creator_id;
+extern uint8_t ak_app_id;
+extern enum AppKeySize ak_appkey_size;
+#define BUFFER_SIZE 64
+
 bool fuji_read_appkey(uint8_t key_id, uint16_t *count, uint8_t *data)
 {
+
+	if (ak_creator_id == 0) {
+		return false;
+	}
+
     struct _ra
     {
         uint8_t opcode;
         uint8_t cmd;
-        uint8_t key_id;
+        uint16_t creator;
+        uint8_t app;
+        uint8_t key;
+        uint8_t mode;
+        uint8_t reserved;
     } ra;
 
     ra.opcode = OP_FUJI;
-    ra.cmd = FUJICMD_READ_APPKEY;
-    ra.key_id = key_id;
+    ra.cmd = FUJICMD_OPEN_APPKEY;
+    ra.key = key_id;
+    ra.creator = ak_creator_id;
+    ra.app = ak_app_id;
+    ra.key = key_id;
+    ra.mode = 0;
 
     bus_ready();
-    
     dwwrite((uint8_t *)&ra, sizeof(ra));
-    // TODO Fix this API, it's broken. shit.
     
-    return bus_error(OP_FUJI) == BUS_SUCCESS;
+    ra.opcode = OP_FUJI;
+    ra.cmd = FUJICMD_READ_APPKEY;
+    
+    bus_ready();
+    dwwrite((uint8_t *)&ra, 2);
+
+    if (bus_error(OP_FUJI)) {
+        return false;
+    }
+
+    bus_get_response(OP_FUJI,(uint8_t *)data,BUFFER_SIZE+2);
+    *count = *(uint16_t*)data;
+    memcpy(data,data+2, BUFFER_SIZE);
+    return true;
 }

--- a/coco/src/fn_fuji/fuji_write_appkey.c
+++ b/coco/src/fn_fuji/fuji_write_appkey.c
@@ -4,8 +4,56 @@
 #include <dw.h>
 #include <fujinet-fuji-coco.h>
 
+extern uint16_t ak_creator_id;
+extern uint8_t ak_app_id;
+extern enum AppKeySize ak_appkey_size;
+#define BUFFER_SIZE 64
+
 bool fuji_write_appkey(uint8_t key_id, uint16_t count, uint8_t *data)
 {
-    // I need to talk with fenrock on why the api for appkeys is like this
-    return bus_error(OP_FUJI) == BUS_SUCCESS;
+    // Minimally viable appkey support for 64 length (DEFAULT) app keys
+
+    struct _ra
+    {
+        uint8_t opcode;
+        uint8_t cmd;
+        uint16_t creator;
+        uint8_t app;
+        uint8_t key;
+        uint8_t mode;
+        uint8_t reserved;
+    } ra;
+
+    struct _wa
+    {
+        uint8_t opcode;
+        uint8_t cmd;
+        uint16_t size;
+        char data[BUFFER_SIZE];
+    } wa;
+
+    if (ak_creator_id == 0) {
+		return false;
+	}
+
+    ra.opcode = OP_FUJI;
+    ra.cmd = FUJICMD_OPEN_APPKEY;
+    ra.key = key_id;
+    ra.creator = ak_creator_id;
+    ra.app = ak_app_id;
+    ra.key = key_id;
+    ra.mode = 1; // Write mode
+
+    bus_ready();
+    dwwrite((uint8_t *)&ra, sizeof(ra));
+    
+    wa.opcode = OP_FUJI;
+    wa.cmd = FUJICMD_WRITE_APPKEY;
+    wa.size = BUFFER_SIZE;
+    memcpy(&wa.data, data, BUFFER_SIZE);
+
+    bus_ready();
+    dwwrite((uint8_t *)&wa, sizeof(wa));
+
+    return true;
 }

--- a/coco/src/fn_network/network_close.c
+++ b/coco/src/fn_network/network_close.c
@@ -12,15 +12,17 @@ uint8_t network_close(char* devicespec)
         uint8_t opcode;
         uint8_t unit;
         uint8_t cmd;
+        uint16_t auxs;
     } nc;
 
     nc.opcode = OP_NET;
     nc.unit = network_unit(devicespec);
     nc.cmd = NETCMD_CLOSE;
+    nc.auxs = 0;
 
     bus_ready();
 
     dwwrite((uint8_t *)&nc, sizeof(nc));
     
-    return bus_error(OP_NET) == BUS_SUCCESS;
+    return bus_error(OP_NET);
 }

--- a/coco/src/fn_network/network_open.c
+++ b/coco/src/fn_network/network_open.c
@@ -27,5 +27,5 @@ uint8_t network_open(char* devicespec, uint8_t mode, uint8_t trans)
     bus_ready();
     dwwrite((uint8_t *)&o, sizeof(o));
     
-    return bus_error(OP_NET) == BUS_SUCCESS;
+    return bus_error(OP_NET);
 }

--- a/coco/src/fn_network/network_status.c
+++ b/coco/src/fn_network/network_status.c
@@ -22,6 +22,8 @@ uint8_t network_status(char *devicespec, uint16_t *bw, uint8_t *c, uint8_t *err)
         uint8_t c;
         uint8_t err;
     } sr;
+    
+    uint8_t status;
 
     s.opcode = OP_NET;
     s.unit = network_unit(devicespec);
@@ -30,11 +32,11 @@ uint8_t network_status(char *devicespec, uint16_t *bw, uint8_t *c, uint8_t *err)
 
     bus_ready();
     dwwrite((uint8_t *)&s, sizeof(s));
-    bus_get_response(OP_NET, (uint8_t *)&sr, sizeof(sr));
+    status = bus_get_response(OP_NET, (uint8_t *)&sr, sizeof(sr));
 
     *bw = sr.bw;
     *c = sr.c;
     *err = sr.err;
     
-    return bus_error(OP_NET) == BUS_SUCCESS;
+    return status;
 }


### PR DESCRIPTION
CoCo updates -
Appkeys functionality (64 byte len)
Updated bus to support both NET and FUJI OPs 
Network open/status/close (and common read) now work
Tested in MAME