### PR TITLE
Code linting

### DIFF
--- a/apple2/apple2gs/bus/sp_find_clock.c
+++ b/apple2/apple2gs/bus/sp_find_clock.c
@@ -5,7 +5,7 @@
 
 uint8_t sp_clock_id = 0;
 
-bool sp_find_clock() {
+bool sp_find_clock(void) {
     int r = sp_find_device("FN_CLOCK");
 	if (r <= 0) {
 		sp_clock_id = 0;
@@ -15,7 +15,7 @@ bool sp_find_clock() {
 	return true;
 }
 
-uint8_t sp_get_clock_id()
+uint8_t sp_get_clock_id(void)
 {
 	if (sp_clock_id != 0) {
 		return sp_clock_id;

--- a/apple2/apple2gs/bus/sp_find_cpm.c
+++ b/apple2/apple2gs/bus/sp_find_cpm.c
@@ -5,7 +5,7 @@
 
 uint8_t sp_cpm_id = 0;
 
-bool sp_find_cpm() {
+bool sp_find_cpm(void) {
     int r = sp_find_device("CPM");
 	if (r <= 0) {
 		sp_cpm_id = 0;
@@ -15,7 +15,7 @@ bool sp_find_cpm() {
 	return true;
 }
 
-uint8_t sp_get_cpm_id()
+uint8_t sp_get_cpm_id(void)
 {
 	if (sp_cpm_id != 0) {
 		return sp_cpm_id;

--- a/apple2/apple2gs/bus/sp_find_modem.c
+++ b/apple2/apple2gs/bus/sp_find_modem.c
@@ -5,7 +5,7 @@
 
 uint8_t sp_modem_id = 0;
 
-bool sp_find_modem() {
+bool sp_find_modem(void) {
     int r = sp_find_device("MODEM");
 	if (r <= 0) {
 		sp_modem_id = 0;
@@ -15,7 +15,7 @@ bool sp_find_modem() {
 	return true;
 }
 
-uint8_t sp_get_modem_id()
+uint8_t sp_get_modem_id(void)
 {
 	if (sp_modem_id != 0) {
 		return sp_modem_id;

--- a/apple2/apple2gs/bus/sp_find_network.c
+++ b/apple2/apple2gs/bus/sp_find_network.c
@@ -5,7 +5,7 @@
 
 uint8_t sp_network = 0;
 
-bool sp_find_network() {
+bool sp_find_network(void) {
     int r = sp_find_device("NETWORK");
 	if (r <= 0) {
 		sp_network = 0;
@@ -15,7 +15,7 @@ bool sp_find_network() {
 	return true;
 }
 
-uint8_t sp_get_network_id()
+uint8_t sp_get_network_id(void)
 {
 	if (sp_network != 0) {
 		return sp_network;

--- a/apple2/apple2gs/bus/sp_find_printer.c
+++ b/apple2/apple2gs/bus/sp_find_printer.c
@@ -5,7 +5,7 @@
 
 uint8_t sp_printer_id = 0;
 
-bool sp_find_printer() {
+bool sp_find_printer(void) {
     int r = sp_find_device("PRINTER");
 	if (r <= 0) {
 		sp_printer_id = 0;
@@ -15,7 +15,7 @@ bool sp_find_printer() {
 	return true;
 }
 
-uint8_t sp_get_printer_id()
+uint8_t sp_get_printer_id(void)
 {
 	if (sp_printer_id != 0) {
 		return sp_printer_id;

--- a/apple2/src/fn_fuji/fuji_base64_decode_compute.c
+++ b/apple2/src/fn_fuji/fuji_base64_decode_compute.c
@@ -1,7 +1,7 @@
 #include <stdint.h>
 #include "fujinet-fuji.h"
 
-bool fuji_base64_decode_compute()
+bool fuji_base64_decode_compute(void)
 {
     return true;
 }

--- a/apple2/src/fn_fuji/fuji_base64_encode_compute.c
+++ b/apple2/src/fn_fuji/fuji_base64_encode_compute.c
@@ -3,7 +3,7 @@
 #include "fujinet-fuji.h"
 #include "fujinet-bus-apple2.h"
 
-bool fuji_base64_encode_compute()
+bool fuji_base64_encode_compute(void)
 {
     // send CTRL command: FUJICMD_BASE64_ENCODE_COMPUTE
     // PAYLOAD: N/A

--- a/apple2/src/fn_fuji/fuji_base64_encode_input.c
+++ b/apple2/src/fn_fuji/fuji_base64_encode_input.c
@@ -12,7 +12,7 @@ bool fuji_base64_encode_input(char *s, uint16_t len)
     // 2+  : string
 
     if (len > MAX_DATA_LEN) return 1;
-    strncpy(sp_payload, s, len);
+    strncpy((char *)sp_payload, s, len);
     return sp_control(0, FUJICMD_BASE64_ENCODE_INPUT) == 0;
 
 }

--- a/apple2/src/fn_fuji/fuji_close_directory.c
+++ b/apple2/src/fn_fuji/fuji_close_directory.c
@@ -2,7 +2,7 @@
 #include "fujinet-fuji.h"
 #include "fujinet-bus-apple2.h"
 
-bool fuji_close_directory()
+bool fuji_close_directory(void)
 {
 	if (sp_get_fuji_id() == 0) {
 		return false;

--- a/apple2/src/fn_fuji/fuji_error.c
+++ b/apple2/src/fn_fuji/fuji_error.c
@@ -2,7 +2,7 @@
 #include "fujinet-fuji.h"
 #include "fujinet-bus-apple2.h"
 
-bool fuji_error()
+bool fuji_error(void)
 {
     // a2 config just returns "sp_error", but that's an int. TYPES DAMN IT
     return sp_error != 0;

--- a/apple2/src/fn_network/network_ioctl.c
+++ b/apple2/src/fn_network/network_ioctl.c
@@ -6,7 +6,7 @@
 #include "fujinet-bus-apple2.h"
 
 extern uint8_t __argsize__;
-extern uint8_t bad_unit();
+extern uint8_t bad_unit(void);
 
 // uint8_t network_ioctl(uint8_t cmd, uint8_t aux1, uint8_t aux2, char* devicespec, int16_t use_aux, void *buffer, uint16_t len);
 //

--- a/apple2/src/fn_network/network_json_parse.c
+++ b/apple2/src/fn_network/network_json_parse.c
@@ -3,7 +3,7 @@
 #include "fujinet-network.h"
 #include "fujinet-bus-apple2.h"
 
-extern uint8_t bad_unit();
+extern uint8_t bad_unit(void);
 
 uint8_t network_json_parse(char *devicespec) {
 	uint8_t err = 0;

--- a/apple2/src/fn_network/network_json_query.c
+++ b/apple2/src/fn_network/network_json_query.c
@@ -3,7 +3,7 @@
 #include "fujinet-network.h"
 #include "fujinet-bus-apple2.h"
 
-extern uint8_t bad_unit();
+extern uint8_t bad_unit(void);
 
 int16_t network_json_query(char *devicespec, char *query, char *s) {
 	uint8_t err = 0;
@@ -23,7 +23,7 @@ int16_t network_json_query(char *devicespec, char *query, char *s) {
 	sp_payload[0] = query_len & 0xFF;
 	sp_payload[1] = query_len >> 8;
 
-	strncpy(sp_payload + 2, (const char *) query, query_len);
+	strncpy((char *)sp_payload + 2, (const char *) query, query_len);
 	err = sp_control_nw(sp_network, 'Q'); // perform JSON Query
 	if (err != 0) {
 		goto do_sp_error;

--- a/apple2/src/fn_network/network_open.c
+++ b/apple2/src/fn_network/network_open.c
@@ -34,6 +34,6 @@ uint8_t network_open(char* devicespec, uint8_t mode, uint8_t trans) {
 	sp_payload[2] = mode;
 	sp_payload[3] = trans;
 
-	strncpy(&sp_payload[4], devicespec, slen);
+	strncpy((char *)&sp_payload[4], devicespec, slen);
 	return sp_control_nw(sp_network, 'O');
 }

--- a/apple2/src/fn_network/network_status.c
+++ b/apple2/src/fn_network/network_status.c
@@ -3,7 +3,7 @@
 #include "fujinet-network.h"
 #include "fujinet-bus-apple2.h"
 
-extern uint8_t bad_unit();
+extern uint8_t bad_unit(void);
 
 // this is often called in a tight loop, so we won't clear the payload to help performance
 uint8_t network_status(char *devicespec, uint16_t *bw, uint8_t *c, uint8_t *err) {

--- a/apple2/src/fn_network/network_write.c
+++ b/apple2/src/fn_network/network_write.c
@@ -3,7 +3,7 @@
 #include "fujinet-network.h"
 #include "fujinet-bus-apple2.h"
 
-extern uint8_t bad_unit();
+extern uint8_t bad_unit(void);
 
 
 #define MAX(a, b) ((a) > (b) ? (a) : (b))

--- a/apple2/src/include/fujinet-bus-apple2.h
+++ b/apple2/src/include/fujinet-bus-apple2.h
@@ -83,7 +83,7 @@ extern uint16_t sp_count;
 // global sp error value set by various routines
 extern int8_t sp_error;
 
-void sp_clr_payload();
+void sp_clr_payload(void);
 
 // these are the 'fuji' device versions
 int8_t sp_status(uint8_t dest, uint8_t statcode);
@@ -100,18 +100,21 @@ int8_t sp_open_nw(uint8_t dest);
 int8_t sp_write_nw(uint8_t dest, uint16_t len);
 
 
-// initilises the dispatch funciton and returns the network device id if found, else returns 0.
-uint8_t sp_init();
+// initilises the dispatch function and returns the network device id if found, else returns 0.
+uint8_t sp_init(void);
+
+// dispose memory handles and shutdown tools (Apple IIgs only)
+void sp_done(void);
 
 uint8_t read_memory(uint8_t offset, uint16_t address);
 
 // These return the found device id or 0 if not found.
-uint8_t sp_get_fuji_id();
-uint8_t sp_get_network_id();
-uint8_t sp_get_clock_id();
-uint8_t sp_get_cpm_id();
-uint8_t sp_get_modem_id();
-uint8_t sp_get_printer_id();
+uint8_t sp_get_fuji_id(void);
+uint8_t sp_get_network_id(void);
+uint8_t sp_get_clock_id(void);
+uint8_t sp_get_cpm_id(void);
+uint8_t sp_get_modem_id(void);
+uint8_t sp_get_printer_id(void);
 
 int sp_find_device(char *name);
 

--- a/apple2/src/include/orca.h
+++ b/apple2/src/include/orca.h
@@ -9,9 +9,9 @@
 
 /* Enforce strict type compatibility checks */
 /* Allow // comments */
-/*#pragma ignore 0x0008*/
+#pragma ignore 0x0008
 
 /* Perform all lint checks but treat them as warnings */
-/*#pragma lint -1;0*/
+#pragma lint -1;0
 
 #endif /* ORCA_H */

--- a/common/src/fn_network/network_init.c
+++ b/common/src/fn_network/network_init.c
@@ -11,7 +11,7 @@
 #include "sp.h"
 #endif
 
-uint8_t network_init()
+uint8_t network_init(void)
 {
   int8_t err = 0;
 

--- a/fujinet-fuji.h
+++ b/fujinet-fuji.h
@@ -246,7 +246,7 @@ extern FNStatus _fuji_status;
  * @brief Closes the currently open directory
  * @return Success status, true if all OK.
  */
-bool fuji_close_directory();
+bool fuji_close_directory(void);
 
 /**
  * @brief Copies a file from given src to dst, with supplied path in copy_spec
@@ -270,7 +270,7 @@ bool fuji_enable_udpstream(uint16_t port, char *host);
  * @brief Returns true if last operation had an error.
  * @return ERROR status, true if there was an error in last operation.
  */
-bool fuji_error();
+bool fuji_error(void);
 
 /**
  * @brief Gets adapter config information from FN, e.g. IP, MAC, BSSID etc.
@@ -347,7 +347,7 @@ bool fuji_get_ssid(NetConfig *net_config);
  * @brief Checks if WIFI is enabled or not. Any device errors will return false also.
  * @return enabled status 
  */
-bool fuji_get_wifi_enabled();
+bool fuji_get_wifi_enabled(void);
 
 /**
  * @brief  Sets status to the wifi status value.
@@ -360,7 +360,7 @@ bool fuji_get_wifi_status(uint8_t *status);
  * @brief Mount all devices
  * @return true if successful, false otherwise
  */
-bool fuji_mount_all();
+bool fuji_mount_all(void);
 
 /**
  * @brief Mount specific device slot
@@ -410,7 +410,7 @@ bool fuji_read_directory(uint8_t maxlen, uint8_t aux2, char *buffer);
  * @brief Reset FN
  * @return true if successful, false if there was an error from FN
  */
-bool fuji_reset();
+bool fuji_reset(void);
 
 /**
  * @brief Scans network for SSIDs and sets count accordingly.
@@ -484,7 +484,7 @@ bool fuji_status(FNStatus *status);
 
 #ifdef __CBM__
 // DEBUGGING
-bool fuji_set_status();
+bool fuji_set_status(void);
 #endif
 
 /**
@@ -527,12 +527,12 @@ void fuji_set_appkey_details(uint16_t creator_id, uint8_t app_id, enum AppKeySiz
 
 // Base64
 // ALL RETURN VALUES ARE SUCCESS STATUS VALUE, i.e. true == success
-bool fuji_base64_decode_compute();
+bool fuji_base64_decode_compute(void);
 bool fuji_base64_decode_input(char *s, uint16_t len);
 bool fuji_base64_decode_length(unsigned long *len);
 bool fuji_base64_decode_output(char *s, uint16_t len);
 
-bool fuji_base64_encode_compute();
+bool fuji_base64_encode_compute(void);
 bool fuji_base64_encode_input(char *s, uint16_t len);
 bool fuji_base64_encode_length(unsigned long *len);
 bool fuji_base64_encode_output(char *s, uint16_t len);
@@ -591,7 +591,7 @@ bool fuji_hash_data(hash_alg_t hash_type, uint8_t *input, uint16_t length, bool 
  * @brief  Clear any data associated with hashing in the Fujinet. Should be called before calculating new hashes when using \ref fuji_hash_add and \ref fuji_hash_calculate. Can also be called to discard any data previously sent to free memory on the FujiNet used for any previous data sent with \ref fuji_hash_add.
  * @return success status of the operation
  */
-bool fuji_hash_clear();
+bool fuji_hash_clear(void);
 
 /**
  * @brief  Adds data that needs to be hashed.

--- a/fujinet-network.h
+++ b/fujinet-network.h
@@ -71,7 +71,7 @@ extern uint8_t fn_network_error;
  * exit early if there is a network issue.
  * @return fujinet-network status/error code (See FN_ERR_* values) and set device specific error if there is any
  */
-uint8_t network_init();
+uint8_t network_init(void);
 
 /**
  * @brief  Get Network Device Status byte


### PR DESCRIPTION
This commit aims to fix some types incompatibilities and empty function prototypes. All these issues were reported by ORCA/C using #pragma lint + #pragma ignore, to enforce more strict type compatibility checks.
These pragmas can be set in `apple2/src/include/orca.h`.
