### PR TITLE
CoCo - Fix data len in host/device slots routines. Format asm

### DIFF
--- a/coco/src/bus/bus_get_response.c
+++ b/coco/src/bus/bus_get_response.c
@@ -40,7 +40,7 @@ uint8_t bus_get_response(uint8_t opcode, uint8_t *buf, int len)
     dwwrite((uint8_t *)&grc, z);
 
     // Return 0 on a successful read (dwread returns 1)
-    return !dwread((uint8_t *)buf, len);
+    return !dwread(buf, len);
 }
 /*
  struct _getresponsecmd

--- a/coco/src/bus/dwread.c
+++ b/coco/src/bus/dwread.c
@@ -14,13 +14,13 @@ byte dwread(byte *s, int l)
     asm
     {
         pshs x,y
-            ldx :s
-            ldy :l
-            jsr [0xD93F]
-            puls y,x
-            tfr cc,b
-            lsrb
-            lsrb
-            andb #$01
-            }
+        ldx :s
+        ldy :l
+        jsr [0xD93F]
+        puls y,x
+        tfr cc,b
+        lsrb
+        lsrb
+        andb #$01
+    }
 }

--- a/coco/src/bus/dwwrite.c
+++ b/coco/src/bus/dwwrite.c
@@ -13,10 +13,10 @@ byte dwwrite(byte *s, int l)
     asm
     {
         pshs x,y
-            ldx :s
-            ldy :l
-            jsr [0xD941]
-            tfr cc,d
-            puls y,x
-            }
+        ldx :s
+        ldy :l
+        jsr [0xD941]
+        tfr cc,d
+        puls y,x
+    }
 }

--- a/coco/src/fn_fuji/fuji_get_device_slots.c
+++ b/coco/src/fn_fuji/fuji_get_device_slots.c
@@ -18,7 +18,7 @@ bool fuji_get_device_slots(DeviceSlot *d, size_t size)
     bus_ready();
 
     dwwrite((uint8_t *)&gds, sizeof(gds));
-    bus_get_response(OP_FUJI,(uint8_t *)d, size);
+    bus_get_response(OP_FUJI,(uint8_t *)d, sizeof(DeviceSlot) * size);
     
     return bus_error(OP_FUJI) == BUS_SUCCESS;
 }

--- a/coco/src/fn_fuji/fuji_get_host_slots.c
+++ b/coco/src/fn_fuji/fuji_get_host_slots.c
@@ -16,9 +16,9 @@ bool fuji_get_host_slots(HostSlot *h, size_t size)
     ghs.cmd = FUJICMD_READ_HOST_SLOTS;
 
     bus_ready();
-
     dwwrite((uint8_t *)&ghs, sizeof(ghs));
-    bus_get_response(OP_FUJI,(uint8_t *)h, size);
+
+    bus_get_response(OP_FUJI,(uint8_t *)h, sizeof(HostSlot) * size);
     
     return bus_error(OP_FUJI) == BUS_SUCCESS;
 }

--- a/coco/src/fn_fuji/fuji_put_device_slots.c
+++ b/coco/src/fn_fuji/fuji_put_device_slots.c
@@ -18,7 +18,7 @@ bool fuji_put_device_slots(DeviceSlot *d, size_t size)
     bus_ready();
     
     dwwrite((uint8_t *)&pds, sizeof(pds));
-    dwwrite((uint8_t *)d, size);
+    dwwrite((uint8_t *)d, sizeof(DeviceSlot) * size);
     
     return bus_error(OP_FUJI) == BUS_SUCCESS;
 }

--- a/coco/src/fn_fuji/fuji_put_host_slots.c
+++ b/coco/src/fn_fuji/fuji_put_host_slots.c
@@ -17,7 +17,7 @@ bool fuji_put_host_slots(HostSlot *h, size_t size)
 
     bus_ready();
     dwwrite((uint8_t *)&phs, sizeof(phs));
-    dwwrite((uint8_t *)h, size);
+    dwwrite((uint8_t *)h, sizeof(HostSlot) * size);
     
     return bus_error(OP_FUJI) == BUS_SUCCESS;
 }


### PR DESCRIPTION
Four routines were sending `len` instead of `sizeof(struct) * len`, resulting in incomplete data being sent/retrieved.