### PR TITLE
Const needed in function declaration for network_http_set_channel_mode

### DIFF
--- a/atari/src/fn_network/network_http_set_channel_mode.c
+++ b/atari/src/fn_network/network_http_set_channel_mode.c
@@ -1,6 +1,6 @@
 #include <stdint.h>
 #include "fujinet-network.h"
 
-uint8_t network_http_set_channel_mode(char *devicespec, uint8_t mode) {
+uint8_t network_http_set_channel_mode(const char *devicespec, uint8_t mode) {
     return network_ioctl('M', 0, mode, devicespec, 0, 0, 0);
 }


### PR DESCRIPTION
Small change.  Just added const to the function declaration.