### PR TITLE
PPM85, CoCo: Fix JSON parsing

### DIFF
--- a/coco/src/fn_network/network_json_parse.c
+++ b/coco/src/fn_network/network_json_parse.c
@@ -18,12 +18,18 @@ uint8_t network_json_parse(const char *devicespec)
 
     jp.opcode = OP_NET;
     jp.unit = network_unit(devicespec);
+    jp.cmd = 0xFC;  // CMD_SET_CHANNEL_MODE;
+    jp.aux1 = 1;    // CHANNELMODE_JSON
+    jp.aux2 = 0;
+
+    bus_ready();    
+    dwwrite((uint8_t *)&jp, sizeof(jp));
+
     jp.cmd = 'P';
     jp.aux1 = jp.aux2 = 0;
 
     bus_ready();
     dwwrite((uint8_t *)&jp, sizeof(jp));
-    bus_ready(); // we want to be sure parse completes.
 
     return network_get_error(jp.unit);
 }

--- a/coco/src/fn_network/network_json_query.c
+++ b/coco/src/fn_network/network_json_query.c
@@ -32,8 +32,8 @@ int16_t network_json_query(const char *devicespec, const char *query, char *s)
 
     network_status(devicespec, &bw, &c, &err);
 
-    if (bw)
-	    network_get_response(unit, (uint8_t *)s, bw);
-    
-    return network_get_error(unit);
+    if (!bw)
+        return 0;
+
+    return network_read(devicespec, (uint8_t *)s, bw);
 }

--- a/pmd85/src/fn_network/network_json_parse.c
+++ b/pmd85/src/fn_network/network_json_parse.c
@@ -16,12 +16,18 @@ uint8_t network_json_parse(const char *devicespec)
 
     jp.opcode = OP_NET;
     jp.unit = network_unit(devicespec);
+    jp.cmd = 0xFC;  // CMD_SET_CHANNEL_MODE;
+    jp.aux1 = 1;    // CHANNELMODE_JSON
+    jp.aux2 = 0;
+
+    bus_ready();    
+    dwwrite((uint8_t *)&jp, sizeof(jp));
+
     jp.cmd = 'P';
     jp.aux1 = jp.aux2 = 0;
 
     bus_ready();
     dwwrite((uint8_t *)&jp, sizeof(jp));
-    bus_ready(); // we want to be sure parse completes.
 
     return network_get_error(jp.unit);
 }

--- a/pmd85/src/fn_network/network_json_query.c
+++ b/pmd85/src/fn_network/network_json_query.c
@@ -31,8 +31,8 @@ int16_t network_json_query(const char *devicespec, const char *query, char *s)
 
     network_status(devicespec, &bw, &c, &err);
 
-    if (bw)
-	    network_get_response(unit, (uint8_t *)s, bw);
-    
-    return network_get_error(unit);
+    if (!bw)
+        return 0;
+
+    return network_read(devicespec, (uint8_t *)s, bw);
 }


### PR DESCRIPTION
- missing channel mode JSON in network_json_parse
- call network_read() in network_json_query